### PR TITLE
Integrate SingleFileManager with regforms

### DIFF
--- a/indico/modules/events/registration/blueprint.py
+++ b/indico/modules/events/registration/blueprint.py
@@ -175,6 +175,8 @@ _bp.add_url_rule('/registrations/', 'display_regform_list', display.RHRegistrati
 _bp.add_url_rule('/registrations/participants', 'participant_list', display.RHParticipantList)
 _bp.add_url_rule('/registrations/<int:reg_form_id>/', 'display_regform', display.RHRegistrationForm,
                  methods=('GET', 'POST'))
+_bp.add_url_rule('/registrations/<int:reg_form_id>/upload', 'upload_registration_file',
+                 display.RHUploadRegistrationFile, methods=('POST',))
 _bp.add_url_rule('/registrations/<int:reg_form_id>/edit', 'edit_registration_display',
                  display.RHRegistrationDisplayEdit, methods=('GET', 'POST'))
 _bp.add_url_rule('/registrations/<int:reg_form_id>/withdraw', 'withdraw_registration',

--- a/indico/modules/events/registration/client/js/form/fields/FileInput.jsx
+++ b/indico/modules/events/registration/client/js/form/fields/FileInput.jsx
@@ -5,69 +5,40 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
+import uploadFileURL from 'indico-url:event_registration.upload_registration_file';
+
 import PropTypes from 'prop-types';
-import React, {useRef, useState} from 'react';
-import {Button} from 'semantic-ui-react';
+import React from 'react';
+import {useSelector} from 'react-redux';
+
+import {FinalSingleFileManager} from 'indico/react/components';
+
+import {getStaticData} from '../../form_setup/selectors';
 
 import '../../../styles/regform.module.scss';
 import './FileInput.module.scss';
 
-export default function FileInput({htmlName, disabled}) {
-  const [file, setFile] = useState();
-  const fileRef = useRef();
-
-  const handleFileChange = e => {
-    setFile(e.target.value.split('\\').pop());
-  };
-
-  const handleFileClear = () => {
-    setFile(null);
-    fileRef.current.value = null;
-  };
-
-  const handleSelectFileClick = () => {
-    fileRef.current.click();
-  };
+export default function FileInput({htmlName, disabled, isRequired}) {
+  const {eventId, regformId} = useSelector(getStaticData);
 
   return (
-    <>
-      <Button.Group size="small">
-        <Button
-          type="button"
-          htmlFor={`${htmlName}-file`}
-          name={htmlName}
-          disabled={disabled}
-          icon="upload"
-          /* https://github.com/Semantic-Org/Semantic-UI-React/issues/4318
-          label={
-            <Label styleName={file ? 'fileinput-label-squarecorners' : ''}>
-              <span styleName="fileinput-label">
-                {file ? file : <Translate>Select File</Translate>}
-              </span>
-            </Label>
-          }
-          */
-          onClick={handleSelectFileClick}
-        />
-        {file && <Button icon="delete" onClick={handleFileClear} />}
-      </Button.Group>
-      <input
-        id={`${htmlName}-file`}
-        disabled={disabled}
-        hidden
-        type="file"
-        ref={fileRef}
-        onChange={handleFileChange}
-      />
-    </>
+    <FinalSingleFileManager
+      name={htmlName}
+      disabled={disabled}
+      required={isRequired}
+      uploadURL={uploadFileURL({event_id: eventId, reg_form_id: regformId})}
+      hideValidationError
+    />
   );
 }
 
 FileInput.propTypes = {
   htmlName: PropTypes.string.isRequired,
   disabled: PropTypes.bool,
+  isRequired: PropTypes.bool,
 };
 
 FileInput.defaultProps = {
   disabled: false,
+  isRequired: false,
 };

--- a/indico/modules/events/registration/client/js/form_submission/RegistrationFormSubmission.jsx
+++ b/indico/modules/events/registration/client/js/form_submission/RegistrationFormSubmission.jsx
@@ -12,20 +12,27 @@ import {useSelector} from 'react-redux';
 
 import {FinalSubmitButton} from 'indico/react/forms';
 import {Translate} from 'indico/react/i18n';
+import {indicoAxios, handleAxiosError} from 'indico/utils/axios';
 
 import FormSection from '../form/FormSection';
 
-import {getNestedSections, getUserInfo} from './selectors';
+import {getNestedSections, getUserInfo, getStaticData} from './selectors';
 
 import '../../styles/regform.module.scss';
 
 export default function RegistrationFormSubmission() {
   const sections = useSelector(getNestedSections);
   const userInfo = useSelector(getUserInfo);
+  const {csrfToken, submitUrl} = useSelector(getStaticData);
 
   const onSubmit = async data => {
+    data = {...data, csrf_token: csrfToken};
     console.log(data);
-    await new Promise(r => setTimeout(r, 2500));
+    try {
+      await indicoAxios.post(submitUrl, data);
+    } catch (err) {
+      handleAxiosError(err);
+    }
   };
 
   return (

--- a/indico/modules/events/registration/client/js/form_submission/index.jsx
+++ b/indico/modules/events/registration/client/js/form_submission/index.jsx
@@ -16,7 +16,17 @@ import reducers from './reducers';
 import RegistrationFormSubmission from './RegistrationFormSubmission';
 
 export default function setupRegformSetup(root) {
-  const {eventId, regformId, currency, management, moderated, userInfo, formData} = root.dataset;
+  const {
+    eventId,
+    regformId,
+    csrfToken,
+    currency,
+    management,
+    moderated,
+    userInfo,
+    submitUrl,
+    formData,
+  } = root.dataset;
 
   const initialData = {
     staticData: {
@@ -25,6 +35,8 @@ export default function setupRegformSetup(root) {
       management: JSON.parse(management),
       moderated: JSON.parse(moderated),
       userInfo: JSON.parse(userInfo),
+      csrfToken,
+      submitUrl,
       currency,
     },
   };

--- a/indico/modules/events/registration/client/js/form_submission/selectors.js
+++ b/indico/modules/events/registration/client/js/form_submission/selectors.js
@@ -11,6 +11,7 @@ import {getStaticData} from '../form_setup/selectors';
 
 // TODO: move common selectors (ie most of the section and currency stuff) into ../form/selectors.js
 export {getNestedSections} from '../form_setup/selectors';
+export {getStaticData} from '../form_setup/selectors';
 
 export const getUserInfo = createSelector(
   getStaticData,

--- a/indico/modules/events/registration/controllers/display.py
+++ b/indico/modules/events/registration/controllers/display.py
@@ -29,6 +29,7 @@ from indico.modules.events.registration.util import (check_registration_email, c
 from indico.modules.events.registration.views import (WPDisplayRegistrationFormConference,
                                                       WPDisplayRegistrationFormSimpleEvent,
                                                       WPDisplayRegistrationParticipantList)
+from indico.modules.files.controllers import UploadFileMixin
 from indico.modules.users.util import send_avatar, send_default_avatar
 from indico.util.fs import secure_filename
 from indico.util.i18n import _
@@ -327,6 +328,19 @@ class RHRegistrationForm(InvitationMixin, RHRegistrationFormRegistrationBase):
                                                management=False,
                                                login_required=self.regform.require_login and not session.user,
                                                is_restricted_access=self.is_restricted_access)
+
+
+class RHUploadRegistrationFile(UploadFileMixin, RHRegistrationFormBase):
+    """
+    Upload a file from a registration form.
+
+    Regform file fields do not wait for the regform to be submitted,
+    but upload the selected files immediately, saving just the genereated uuid.
+    Only this uuid is then sent when the regform is submitted.
+    """
+
+    def get_file_context(self):
+        return 'event', self.event.id, 'regform', self.regform.id, 'registration'
 
 
 class RHRegistrationDisplayEdit(RegistrationEditMixin, RHRegistrationFormRegistrationBase):

--- a/indico/modules/events/registration/fields/simple.py
+++ b/indico/modules/events/registration/fields/simple.py
@@ -5,7 +5,6 @@
 # modify it under the terms of the MIT License; see the
 # LICENSE file for more details.
 
-import mimetypes
 from datetime import datetime
 from operator import itemgetter
 
@@ -19,9 +18,9 @@ from indico.core.marshmallow import mm
 from indico.modules.events.registration.fields.base import (BillableFieldDataSchema,
                                                             LimitedPlacesBillableFieldDataSchema,
                                                             RegistrationFormBillableField, RegistrationFormFieldBase)
+from indico.modules.files.models.files import File
 from indico.util.countries import get_countries, get_country
 from indico.util.date_time import strftime_all_years
-from indico.util.fs import secure_client_filename
 from indico.util.i18n import L_, _
 from indico.util.string import normalize_phone_number
 from indico.web.forms.fields import IndicoRadioField
@@ -311,22 +310,26 @@ class _DeletableFileField(wtforms.FileField):
 
 class FileField(RegistrationFormFieldBase):
     name = 'file'
-    wtf_field_class = _DeletableFileField
+    # Toggle this to make the angular form work
+    # wtf_field_class = _DeletableFileField
+    wtf_field_class = wtforms.StringField
 
     def process_form_data(self, registration, value, old_data=None, billable_items_locked=False):
         data = {'field_data': self.form_item.current_data}
         if not value:
+            data['file'] = None
             return data
-        file_ = value['uploaded_file']
-        if file_:
+
+        if file := File.query.filter(File.uuid == value, ~File.claimed).first():
             # we have a file -> always save it
             data['file'] = {
-                'data': file_.stream,
-                'name': secure_client_filename(file_.filename),
-                'content_type': mimetypes.guess_type(file_.filename)[0] or file_.mimetype or 'application/octet-stream'
+                'data': file.open(),
+                'name': file.filename,
+                'content_type': file.content_type
             }
-        elif not value['keep_existing']:
-            data['file'] = None
+        else:
+            # TODO: Handle this case when we remove wtfforms from regform submission
+            raise ValidationError(_('Invalid file UUID'))
         return data
 
     @property

--- a/indico/modules/events/registration/fields/simple.py
+++ b/indico/modules/events/registration/fields/simple.py
@@ -322,13 +322,9 @@ class FileField(RegistrationFormFieldBase):
 
         if file := File.query.filter(File.uuid == value, ~File.claimed).first():
             # we have a file -> always save it
-            data['file'] = {
-                'data': file.open(),
-                'name': file.filename,
-                'content_type': file.content_type
-            }
+            data['file'] = file
         else:
-            # TODO: Handle this case when we remove wtfforms from regform submission
+            # TODO: Handle this case when we remove wtforms from regform submission
             raise ValidationError(_('Invalid file UUID'))
         return data
 

--- a/indico/modules/events/registration/models/registrations.py
+++ b/indico/modules/events/registration/models/registrations.py
@@ -682,17 +682,18 @@ class RegistrationData(StoredFileMixin, db.Model):
     def user_data(self):
         return self.filename if self.field_data.field.input_type == 'file' else self.data
 
-    def _set_file(self, file_info):
+    def _set_file(self, file):
         # in case we are deleting/replacing a file
         self.storage_backend = None
         self.storage_file_id = None
         self.filename = None
         self.content_type = None
         self.size = None
-        if file_info is not None:
-            self.filename = file_info['name']
-            self.content_type = file_info['content_type']
-            self.save(file_info['data'])
+        if file:
+            self.filename = file.filename
+            self.content_type = file.content_type
+            with file.open() as f:
+                self.save(f)
 
     file = property(fset=_set_file)
     del _set_file

--- a/indico/modules/events/registration/templates/display/regform_display.html
+++ b/indico/modules/events/registration/templates/display/regform_display.html
@@ -112,6 +112,8 @@
         <div id="registration-form-submission-container"
              data-event-id="{{ event.id }}"
              data-regform-id="{{ regform.id }}"
+             data-csrf-token="{{ session.csrf_token }}"
+             data-submit-url="{{ request.url }}"
              data-currency="{{ regform.currency }}"
              data-form-data="{{ form_data | tojson | forceescape }}"
              data-user-info="{{ user_data | tojson | forceescape }}"


### PR DESCRIPTION
_Work in progress_

- File input now uses `FinalSingleFileManager`.
- New endpoint to upload regform files - `/registrations/<int:reg_form_id>/upload`
- Made the react regform actually submit so that we can test the backend changes