### PR TITLE
Use a marshmallow schema for regfom submissions

### DIFF
--- a/indico/modules/events/registration/client/js/form/fields/BooleanInput.jsx
+++ b/indico/modules/events/registration/client/js/form/fields/BooleanInput.jsx
@@ -72,13 +72,17 @@ function BooleanInputComponent({
 }
 
 BooleanInputComponent.propTypes = {
-  value: PropTypes.bool.isRequired,
+  value: PropTypes.bool,
   onChange: PropTypes.func.isRequired,
   disabled: PropTypes.bool.isRequired,
   required: PropTypes.bool.isRequired,
   price: PropTypes.number.isRequired,
   placesLimit: PropTypes.number.isRequired,
   placesUsed: PropTypes.number.isRequired,
+};
+
+BooleanInputComponent.defaultProps = {
+  value: null,
 };
 
 export default function BooleanInput({
@@ -91,6 +95,8 @@ export default function BooleanInput({
   placesLimit,
   placesUsed,
 }) {
+  defaultValue = {yes: true, no: false}[defaultValue] || null;
+
   return (
     <FinalField
       name={htmlName}
@@ -98,7 +104,7 @@ export default function BooleanInput({
       component={BooleanInputComponent}
       required={isRequired}
       disabled={disabled}
-      alowNull
+      allowNull
       fieldProps={{className: styles.field}}
       price={price}
       placesLimit={placesLimit}
@@ -113,7 +119,7 @@ BooleanInput.propTypes = {
   disabled: PropTypes.bool,
   title: PropTypes.string.isRequired,
   isRequired: PropTypes.bool,
-  defaultValue: PropTypes.bool,
+  defaultValue: PropTypes.string,
   price: PropTypes.number,
   placesLimit: PropTypes.number,
   placesUsed: PropTypes.number,
@@ -122,7 +128,7 @@ BooleanInput.propTypes = {
 BooleanInput.defaultProps = {
   disabled: false,
   isRequired: false,
-  defaultValue: null,
+  defaultValue: '',
   price: 0,
   placesLimit: 0,
   placesUsed: 0,
@@ -130,8 +136,8 @@ BooleanInput.defaultProps = {
 
 export function BooleanSettings() {
   const options = [
-    {key: 'yes', value: true, text: Translate.string('Yes')},
-    {key: 'no', value: false, text: Translate.string('No')},
+    {key: 'yes', value: 'yes', text: Translate.string('Yes')},
+    {key: 'no', value: 'no', text: Translate.string('No')},
   ];
   return (
     <>

--- a/indico/modules/events/registration/client/js/form/fields/BooleanInput.jsx
+++ b/indico/modules/events/registration/client/js/form/fields/BooleanInput.jsx
@@ -31,7 +31,7 @@ function BooleanInputComponent({
   const currency = useSelector(getCurrency);
   const makeOnClick = newValue => () => {
     if (value === newValue && !required) {
-      onChange('');
+      onChange(null);
     } else {
       onChange(newValue);
     }
@@ -42,23 +42,23 @@ function BooleanInputComponent({
       <Button.Group>
         <Button
           type="button"
-          active={value === 'yes'}
+          active={value === true}
           disabled={disabled || (placesLimit > 0 && placesUsed >= placesLimit)}
-          onClick={makeOnClick('yes')}
+          onClick={makeOnClick(true)}
         >
           <Translate>Yes</Translate>
         </Button>
         <Button
           type="button"
-          active={value === 'no'}
+          active={value === false}
           disabled={disabled}
-          onClick={makeOnClick('no')}
+          onClick={makeOnClick(false)}
         >
           <Translate>No</Translate>
         </Button>
       </Button.Group>
       {!!price && (
-        <Label pointing="left" styleName={`price-tag ${value !== 'yes' ? 'greyed' : ''}`}>
+        <Label pointing="left" styleName={`price-tag ${value !== true ? 'greyed' : ''}`}>
           {price.toFixed(2)} {currency}
         </Label>
       )}
@@ -72,7 +72,7 @@ function BooleanInputComponent({
 }
 
 BooleanInputComponent.propTypes = {
-  value: PropTypes.string.isRequired,
+  value: PropTypes.bool.isRequired,
   onChange: PropTypes.func.isRequired,
   disabled: PropTypes.bool.isRequired,
   required: PropTypes.bool.isRequired,
@@ -98,6 +98,7 @@ export default function BooleanInput({
       component={BooleanInputComponent}
       required={isRequired}
       disabled={disabled}
+      alowNull
       fieldProps={{className: styles.field}}
       price={price}
       placesLimit={placesLimit}
@@ -112,7 +113,7 @@ BooleanInput.propTypes = {
   disabled: PropTypes.bool,
   title: PropTypes.string.isRequired,
   isRequired: PropTypes.bool,
-  defaultValue: PropTypes.string,
+  defaultValue: PropTypes.bool,
   price: PropTypes.number,
   placesLimit: PropTypes.number,
   placesUsed: PropTypes.number,
@@ -121,7 +122,7 @@ BooleanInput.propTypes = {
 BooleanInput.defaultProps = {
   disabled: false,
   isRequired: false,
-  defaultValue: '',
+  defaultValue: null,
   price: 0,
   placesLimit: 0,
   placesUsed: 0,
@@ -129,8 +130,8 @@ BooleanInput.defaultProps = {
 
 export function BooleanSettings() {
   const options = [
-    {key: 'yes', value: 'yes', text: Translate.string('Yes')},
-    {key: 'no', value: 'no', text: Translate.string('No')},
+    {key: 'yes', value: true, text: Translate.string('Yes')},
+    {key: 'no', value: false, text: Translate.string('No')},
   ];
   return (
     <>

--- a/indico/modules/events/registration/client/js/form_submission/RegistrationFormSubmission.jsx
+++ b/indico/modules/events/registration/client/js/form_submission/RegistrationFormSubmission.jsx
@@ -29,10 +29,15 @@ export default function RegistrationFormSubmission() {
 
   const onSubmit = async data => {
     console.log(data);
+    let resp;
     try {
-      await indicoAxios.post(submitUrl, data);
+      resp = await indicoAxios.post(submitUrl, data);
     } catch (err) {
       return handleSubmitError(err);
+    }
+
+    if (resp.data.redirect) {
+      location.href = resp.data.redirect;
     }
   };
 

--- a/indico/modules/events/registration/client/js/form_submission/RegistrationFormSubmission.jsx
+++ b/indico/modules/events/registration/client/js/form_submission/RegistrationFormSubmission.jsx
@@ -15,19 +15,19 @@ import {Translate} from 'indico/react/i18n';
 import {indicoAxios} from 'indico/utils/axios';
 
 import FormSection from '../form/FormSection';
-import {getNestedSections, getStaticData} from '../form/selectors';
+import {getItems, getNestedSections, getStaticData} from '../form/selectors';
 
 import {getUserInfo} from './selectors';
 
 import '../../styles/regform.module.scss';
 
 export default function RegistrationFormSubmission() {
+  const items = useSelector(getItems);
   const sections = useSelector(getNestedSections);
   const userInfo = useSelector(getUserInfo);
-  const {csrfToken, submitUrl} = useSelector(getStaticData);
+  const {submitUrl} = useSelector(getStaticData);
 
   const onSubmit = async data => {
-    data = {...data, csrf_token: csrfToken};
     console.log(data);
     try {
       await indicoAxios.post(submitUrl, data);
@@ -36,10 +36,19 @@ export default function RegistrationFormSubmission() {
     }
   };
 
+  const initialValues = Object.fromEntries(
+    Object.entries(userInfo).filter(([key]) => {
+      return Object.values(items).some(
+        ({htmlName, fieldIsPersonalData, isEnabled}) =>
+          htmlName === key && fieldIsPersonalData && isEnabled
+      );
+    })
+  );
+
   return (
     <FinalForm
       onSubmit={onSubmit}
-      initialValues={userInfo}
+      initialValues={initialValues}
       initialValuesEqual={_.isEqual}
       subscription={{}}
     >

--- a/indico/modules/events/registration/client/js/form_submission/RegistrationFormSubmission.jsx
+++ b/indico/modules/events/registration/client/js/form_submission/RegistrationFormSubmission.jsx
@@ -10,9 +10,9 @@ import React from 'react';
 import {Form as FinalForm} from 'react-final-form';
 import {useSelector} from 'react-redux';
 
-import {FinalSubmitButton} from 'indico/react/forms';
+import {FinalSubmitButton, handleSubmitError} from 'indico/react/forms';
 import {Translate} from 'indico/react/i18n';
-import {indicoAxios, handleAxiosError} from 'indico/utils/axios';
+import {indicoAxios} from 'indico/utils/axios';
 
 import FormSection from '../form/FormSection';
 import {getNestedSections, getStaticData} from '../form/selectors';
@@ -32,7 +32,7 @@ export default function RegistrationFormSubmission() {
     try {
       await indicoAxios.post(submitUrl, data);
     } catch (err) {
-      handleAxiosError(err);
+      return handleSubmitError(err);
     }
   };
 

--- a/indico/modules/events/registration/client/js/form_submission/index.jsx
+++ b/indico/modules/events/registration/client/js/form_submission/index.jsx
@@ -19,7 +19,6 @@ export default function setupRegformSetup(root) {
   const {
     eventId,
     regformId,
-    csrfToken,
     currency,
     management,
     moderated,
@@ -35,7 +34,6 @@ export default function setupRegformSetup(root) {
       management: JSON.parse(management),
       moderated: JSON.parse(moderated),
       userInfo: JSON.parse(userInfo),
-      csrfToken,
       submitUrl,
       currency,
     },

--- a/indico/modules/events/registration/controllers/__init__.py
+++ b/indico/modules/events/registration/controllers/__init__.py
@@ -34,12 +34,12 @@ class RegistrationFormMixin:
 class RegistrationEditMixin:
     def _process_POST(self):
         schema = make_registration_schema(self.regform, management=self.management, registration=self.registration)()
-        form = parser.parse(schema)
+        form_data = parser.parse(schema)
 
-        notify_user = not self.management or form.pop('notify_user', False)
+        notify_user = not self.management or form_data.pop('notify_user', False)
         if self.management:
             session['registration_notify_user_default'] = notify_user
-        modify_registration(self.registration, form, management=self.management, notify_user=notify_user)
+        modify_registration(self.registration, form_data, management=self.management, notify_user=notify_user)
         return redirect(self.success_url)
 
     def _process_GET(self):

--- a/indico/modules/events/registration/controllers/__init__.py
+++ b/indico/modules/events/registration/controllers/__init__.py
@@ -5,12 +5,14 @@
 # modify it under the terms of the MIT License; see the
 # LICENSE file for more details.
 
-from flask import flash, redirect, request, session
+from flask import redirect, request, session
 from sqlalchemy.orm import defaultload
 
 from indico.modules.events.registration.models.forms import RegistrationForm
-from indico.modules.events.registration.util import get_event_section_data, make_registration_form, modify_registration
+from indico.modules.events.registration.util import (get_event_section_data, make_registration_schema,
+                                                     modify_registration)
 from indico.util.string import camelize_keys
+from indico.web.args import parser
 
 
 class RegistrationFormMixin:
@@ -30,21 +32,17 @@ class RegistrationFormMixin:
 
 
 class RegistrationEditMixin:
-    def _process(self):
-        form = make_registration_form(self.regform, management=self.management, registration=self.registration)()
+    def _process_POST(self):
+        schema = make_registration_schema(self.regform, management=self.management, registration=self.registration)()
+        form = parser.parse(schema)
 
-        if form.validate_on_submit():
-            data = form.data
-            notify_user = not self.management or data.pop('notify_user', False)
-            if self.management:
-                session['registration_notify_user_default'] = notify_user
-            modify_registration(self.registration, data, management=self.management, notify_user=notify_user)
-            return redirect(self.success_url)
-        elif form.is_submitted():
-            # not very pretty but usually this never happens thanks to client-side validation
-            for error in form.error_list:
-                flash(error, 'error')
+        notify_user = not self.management or form.pop('notify_user', False)
+        if self.management:
+            session['registration_notify_user_default'] = notify_user
+        modify_registration(self.registration, form, management=self.management, notify_user=notify_user)
+        return redirect(self.success_url)
 
+    def _process_GET(self):
         registration_data = {r.field_data.field.html_field_name: camelize_keys(r.user_data)
                              for r in self.registration.data}
         section_data = camelize_keys(get_event_section_data(self.regform, management=self.management,

--- a/indico/modules/events/registration/controllers/display.py
+++ b/indico/modules/events/registration/controllers/display.py
@@ -315,7 +315,7 @@ class RHRegistrationForm(InvitationMixin, RHRegistrationFormRegistrationBase):
 
         if self._can_register():
             registration = create_registration(self.regform, form, self.invitation)
-            return redirect(url_for('.display_regform', registration.locator.registrant))
+            return jsonify({'redirect': url_for('.display_regform', registration.locator.registrant)})
         return self._process_GET()
 
     def _process_GET(self):

--- a/indico/modules/events/registration/controllers/display.py
+++ b/indico/modules/events/registration/controllers/display.py
@@ -35,7 +35,7 @@ from indico.modules.users.util import send_avatar, send_default_avatar
 from indico.util.fs import secure_filename
 from indico.util.i18n import _
 from indico.util.marshmallow import UUIDString
-from indico.web.args import use_kwargs
+from indico.web.args import parser, use_kwargs
 from indico.web.flask.util import send_file, url_for
 
 
@@ -311,17 +311,12 @@ class RHRegistrationForm(InvitationMixin, RHRegistrationFormRegistrationBase):
 
     def _process_POST(self):
         schema = make_registration_schema(self.regform)()
-        errors = schema.validate(request.json)
+        form = parser.parse(schema)
 
-        if self._can_register() and not errors:
-            form = schema.load(request.json)
+        if self._can_register():
             registration = create_registration(self.regform, form, self.invitation)
             return redirect(url_for('.display_regform', registration.locator.registrant))
-        else:
-            # not very pretty but usually this never happens thanks to client-side validation
-            for field in errors:
-                flash(f'{field}: {errors[field]}', 'error')
-            return self._process_GET()
+        return self._process_GET()
 
     def _process_GET(self):
         user_data = {t.name: getattr(session.user, t.name, None) if session.user else '' for t in PersonalDataType}

--- a/indico/modules/events/registration/controllers/display.py
+++ b/indico/modules/events/registration/controllers/display.py
@@ -26,7 +26,7 @@ from indico.modules.events.registration.models.registrations import Registration
 from indico.modules.events.registration.util import (check_registration_email, create_registration, generate_ticket,
                                                      get_event_regforms_registrations, get_event_section_data,
                                                      get_flat_section_submission_data, get_title_uuid,
-                                                     make_registration_form)
+                                                     make_registration_schema)
 from indico.modules.events.registration.views import (WPDisplayRegistrationFormConference,
                                                       WPDisplayRegistrationFormSimpleEvent,
                                                       WPDisplayRegistrationParticipantList)
@@ -309,16 +309,21 @@ class RHRegistrationForm(InvitationMixin, RHRegistrationFormRegistrationBase):
             return False
         return True
 
-    def _process(self):
-        form = make_registration_form(self.regform)()
-        if self._can_register() and form.validate_on_submit():
-            registration = create_registration(self.regform, form.data, self.invitation)
-            return redirect(url_for('.display_regform', registration.locator.registrant))
-        elif form.is_submitted():
-            # not very pretty but usually this never happens thanks to client-side validation
-            for error in form.error_list:
-                flash(error, 'error')
+    def _process_POST(self):
+        schema = make_registration_schema(self.regform)()
+        errors = schema.validate(request.json)
 
+        if self._can_register() and not errors:
+            form = schema.load(request.json)
+            registration = create_registration(self.regform, form, self.invitation)
+            return redirect(url_for('.display_regform', registration.locator.registrant))
+        else:
+            # not very pretty but usually this never happens thanks to client-side validation
+            for field in errors:
+                flash(f'{field}: {errors[field]}', 'error')
+            return self._process_GET()
+
+    def _process_GET(self):
         user_data = {t.name: getattr(session.user, t.name, None) if session.user else '' for t in PersonalDataType}
         if self.invitation:
             user_data.update((attr, getattr(self.invitation, attr)) for attr in ('first_name', 'last_name', 'email'))

--- a/indico/modules/events/registration/controllers/management/reglists.py
+++ b/indico/modules/events/registration/controllers/management/reglists.py
@@ -283,7 +283,7 @@ class RHRegistrationCreate(RHManageRegFormBase):
         session['registration_notify_user_default'] = notify_user = form.pop('notify_user', False)
         create_registration(self.regform, form, management=True, notify_user=notify_user)
         flash(_('The registration was created.'), 'success')
-        return redirect(url_for('.manage_reglist', self.regform))
+        return jsonify({'redirect': url_for('.manage_reglist', self.regform)})
 
     def _process_GET(self):
         return WPManageRegistration.render_template('display/regform_display.html', self.event,

--- a/indico/modules/events/registration/fields/base.py
+++ b/indico/modules/events/registration/fields/base.py
@@ -60,9 +60,8 @@ class RegistrationFormFieldBase:
     def default_value(self):
         return ''
 
-    @property
-    def validators(self):
-        """Return a list of validators for this field."""
+    def validators(self, **kwargs):
+        """Return a list of marshmallow validators for this field."""
         return None
 
     @property
@@ -98,8 +97,18 @@ class RegistrationFormFieldBase:
         schema = self.setup_schema_base_cls.from_dict(self.setup_schema_fields, name=name)
         return schema()
 
-    def create_mm_field(self):
-        return self.mm_field_class(required=self.form_item.is_required, **self.mm_field_kwargs)
+    def create_mm_field(self, registration=None):
+        """
+        Create a a marshmallow field.
+        When modifying an existing registration, the `registration` parameter is
+        the previous registration. We pass the registration because
+        some field validators need the old data.
+
+        :param registration: The previous registration if modifying an existing one, otherwise none
+        """
+        return self.mm_field_class(required=self.form_item.is_required,
+                                   validate=self.validators(registration=registration),
+                                   **self.mm_field_kwargs)
 
     def has_data_changed(self, value, old_data):
         return value != old_data.data

--- a/indico/modules/events/registration/fields/base.py
+++ b/indico/modules/events/registration/fields/base.py
@@ -44,6 +44,10 @@ class RegistrationFormFieldBase:
     not_required_validator = Optional
     #: the data fields that need to be versioned
     versioned_data_fields = frozenset({'price'})
+    #: the marshmallow base field for regform submission
+    mm_field_class = fields.Field
+    #: additional options for the marshmallow field
+    mm_field_kwargs = {}
     #: the marshmallow base schema for configuring the field
     setup_schema_base_cls = mm.Schema
     #: a dict with extra marshmallow fields to include in the setup schema
@@ -93,6 +97,9 @@ class RegistrationFormFieldBase:
         name = f'{type(self).__name__}SetupDataSchema'
         schema = self.setup_schema_base_cls.from_dict(self.setup_schema_fields, name=name)
         return schema()
+
+    def create_mm_field(self):
+        return self.mm_field_class(required=self.form_item.is_required, **self.mm_field_kwargs)
 
     def has_data_changed(self, value, old_data):
         return value != old_data.data

--- a/indico/modules/events/registration/fields/base.py
+++ b/indico/modules/events/registration/fields/base.py
@@ -99,7 +99,7 @@ class RegistrationFormFieldBase:
 
     def create_mm_field(self, registration=None):
         """
-        Create a a marshmallow field.
+        Create a marshmallow field.
         When modifying an existing registration, the `registration` parameter is
         the previous registration. We pass the registration because
         some field validators need the old data.

--- a/indico/modules/events/registration/fields/base.py
+++ b/indico/modules/events/registration/fields/base.py
@@ -44,8 +44,8 @@ class RegistrationFormFieldBase:
     not_required_validator = Optional
     #: the data fields that need to be versioned
     versioned_data_fields = frozenset({'price'})
-    #: the marshmallow base field for regform submission
-    mm_field_class = fields.Field
+    #: the marshmallow field class for regform submission
+    mm_field_class = None
     #: additional options for the marshmallow field
     mm_field_kwargs = {}
     #: the marshmallow base schema for configuring the field

--- a/indico/modules/events/registration/fields/choices.py
+++ b/indico/modules/events/registration/fields/choices.py
@@ -114,6 +114,8 @@ class SingleChoiceSetupSchema(ChoiceSetupSchema):
 class ChoiceBaseField(RegistrationFormBillableItemsField):
     versioned_data_fields = RegistrationFormBillableItemsField.versioned_data_fields | {'choices'}
     has_default_item = False
+    mm_field_class = fields.Dict
+    mm_field_kwargs = {'keys': fields.String(), 'values': fields.Integer()}
     wtf_field_class = JSONField
 
     @classmethod

--- a/indico/modules/events/registration/fields/choices.py
+++ b/indico/modules/events/registration/fields/choices.py
@@ -450,8 +450,8 @@ class AccommodationSetupSchema(mm.Schema):
 class AccommodationSchema(mm.Schema):
     choice = UUIDString()
     isNoAccommodation = fields.Bool(required=True)
-    arrivalDate = fields.Date()
-    departureDate = fields.Date()
+    arrivalDate = fields.Date(allow_none=True)
+    departureDate = fields.Date(allow_none=True)
 
     @validates_schema(skip_on_field_errors=True)
     def validate_everything(self, data, **kwargs):

--- a/indico/modules/events/registration/fields/simple.py
+++ b/indico/modules/events/registration/fields/simple.py
@@ -11,7 +11,6 @@ from operator import itemgetter
 import wtforms
 from marshmallow import ValidationError as MMValidationError
 from marshmallow import fields, pre_load, validate, validates_schema
-from werkzeug.datastructures import FileStorage
 from wtforms.validators import InputRequired, NumberRange, ValidationError
 
 from indico.core.marshmallow import mm
@@ -287,25 +286,8 @@ class CountryField(RegistrationFormFieldBase):
         return get_country(registration_data.data) if registration_data.data else ''
 
 
-class _DeletableFileField(wtforms.FileField):
-    def process_formdata(self, valuelist):
-        if not valuelist:
-            self.data = {'keep_existing': False, 'uploaded_file': None}
-        else:
-            # This expects a form with a hidden field and a file field with the same name.
-            # If the hidden field is empty, it indicates that an existing file should be
-            # deleted or replaced with the newly uploaded file.
-            keep_existing = '' not in valuelist
-            uploaded_file = next((x for x in valuelist if isinstance(x, FileStorage)), None)
-            if not uploaded_file or not uploaded_file.filename:
-                uploaded_file = None
-            self.data = {'keep_existing': keep_existing, 'uploaded_file': uploaded_file}
-
-
 class FileField(RegistrationFormFieldBase):
     name = 'file'
-    # Toggle this to make the angular form work
-    # wtf_field_class = _DeletableFileField
     wtf_field_class = wtforms.StringField
 
     def process_form_data(self, registration, value, old_data=None, billable_items_locked=False):

--- a/indico/modules/events/registration/fields/simple.py
+++ b/indico/modules/events/registration/fields/simple.py
@@ -203,7 +203,7 @@ class BooleanField(RegistrationFormBillableField):
     mm_field_class = fields.Boolean
     setup_schema_base_cls = LimitedPlacesBillableFieldDataSchema
     setup_schema_fields = {
-        'default_value': fields.String(load_default='', validate=validate.OneOf(['', 'yes', 'no'])),
+        'default_value': fields.Boolean(),
     }
     friendly_data_mapping = {None: '',
                              True: L_('Yes'),

--- a/indico/modules/events/registration/fields/simple.py
+++ b/indico/modules/events/registration/fields/simple.py
@@ -201,6 +201,7 @@ class BooleanField(RegistrationFormBillableField):
     wtf_field_class = IndicoRadioField
     required_validator = InputRequired
     mm_field_class = fields.Boolean
+    mm_field_kwargs = {'allow_none': True}
     setup_schema_base_cls = LimitedPlacesBillableFieldDataSchema
     setup_schema_fields = {
         'default_value': fields.String(load_default='', validate=validate.OneOf(['', 'yes', 'no'])),

--- a/indico/modules/events/registration/fields/simple.py
+++ b/indico/modules/events/registration/fields/simple.py
@@ -203,7 +203,7 @@ class BooleanField(RegistrationFormBillableField):
     mm_field_class = fields.Boolean
     setup_schema_base_cls = LimitedPlacesBillableFieldDataSchema
     setup_schema_fields = {
-        'default_value': fields.Boolean(),
+        'default_value': fields.String(load_default='', validate=validate.OneOf(['', 'yes', 'no'])),
     }
     friendly_data_mapping = {None: '',
                              True: L_('Yes'),

--- a/indico/modules/events/registration/fields/simple.py
+++ b/indico/modules/events/registration/fields/simple.py
@@ -29,6 +29,7 @@ from indico.web.forms.validators import IndicoEmail
 class TextField(RegistrationFormFieldBase):
     name = 'text'
     wtf_field_class = wtforms.StringField
+    mm_field_class = fields.String
     setup_schema_fields = {
         'min_length': fields.Integer(load_default=None, validate=validate.Range(1)),
         'max_length': fields.Integer(load_default=None, validate=validate.Range(1)),
@@ -49,6 +50,7 @@ class NumberField(RegistrationFormBillableField):
     name = 'number'
     wtf_field_class = wtforms.IntegerField
     required_validator = InputRequired
+    mm_field_class = fields.Integer
     setup_schema_base_cls = NumberFieldDataSchema
 
     @property
@@ -68,6 +70,7 @@ class NumberField(RegistrationFormBillableField):
 class TextAreaField(RegistrationFormFieldBase):
     name = 'textarea'
     wtf_field_class = wtforms.StringField
+    mm_field_class = fields.String
     setup_schema_fields = {
         'number_of_rows': fields.Integer(load_default=None, validate=validate.Range(1, 20)),
     }
@@ -76,6 +79,7 @@ class TextAreaField(RegistrationFormFieldBase):
 class CheckboxField(RegistrationFormBillableField):
     name = 'checkbox'
     wtf_field_class = wtforms.BooleanField
+    mm_field_class = fields.Boolean
     setup_schema_base_cls = LimitedPlacesBillableFieldDataSchema
     friendly_data_mapping = {None: '',
                              True: L_('Yes'),
@@ -165,6 +169,7 @@ class DateFieldDataSchema(mm.Schema):
 class DateField(RegistrationFormFieldBase):
     name = 'date'
     wtf_field_class = wtforms.StringField
+    mm_field_class = fields.String
     setup_schema_base_cls = DateFieldDataSchema
 
     @classmethod
@@ -198,6 +203,7 @@ class BooleanField(RegistrationFormBillableField):
     name = 'bool'
     wtf_field_class = IndicoRadioField
     required_validator = InputRequired
+    mm_field_class = fields.Boolean
     setup_schema_base_cls = LimitedPlacesBillableFieldDataSchema
     setup_schema_fields = {
         'default_value': fields.String(load_default='', validate=validate.OneOf(['', 'yes', 'no'])),
@@ -258,11 +264,13 @@ class PhoneField(RegistrationFormFieldBase):
     name = 'phone'
     wtf_field_class = wtforms.StringField
     wtf_field_kwargs = {'filters': [lambda x: normalize_phone_number(x) if x else '']}
+    mm_field_class = fields.String
 
 
 class CountryField(RegistrationFormFieldBase):
     name = 'country'
     wtf_field_class = wtforms.SelectField
+    mm_field_class = fields.String
 
     @property
     def wtf_field_kwargs(self):
@@ -289,6 +297,7 @@ class CountryField(RegistrationFormFieldBase):
 class FileField(RegistrationFormFieldBase):
     name = 'file'
     wtf_field_class = wtforms.StringField
+    mm_field_class = fields.String
 
     def process_form_data(self, registration, value, old_data=None, billable_items_locked=False):
         data = {'field_data': self.form_item.current_data}
@@ -318,6 +327,7 @@ class EmailField(RegistrationFormFieldBase):
     name = 'email'
     wtf_field_class = wtforms.StringField
     wtf_field_kwargs = {'filters': [lambda x: x.lower() if x else x]}
+    mm_field_class = fields.Email
 
     @property
     def validators(self):

--- a/indico/modules/events/registration/templates/display/regform_display.html
+++ b/indico/modules/events/registration/templates/display/regform_display.html
@@ -112,7 +112,6 @@
         <div id="registration-form-submission-container"
              data-event-id="{{ event.id }}"
              data-regform-id="{{ regform.id }}"
-             data-csrf-token="{{ session.csrf_token }}"
              data-submit-url="{{ request.url }}"
              data-currency="{{ regform.currency }}"
              data-form-data="{{ form_data | tojson | forceescape }}"

--- a/indico/modules/events/registration/util.py
+++ b/indico/modules/events/registration/util.py
@@ -268,7 +268,7 @@ def make_registration_schema(regform, management=False, registration=None):
             continue
 
         field_impl = form_item.field_impl
-        schema[form_item.html_field_name] = field_impl.create_mm_field()
+        schema[form_item.html_field_name] = field_impl.create_mm_field(registration=registration)
 
     # TODO: what to do with signal -> signals.event.registration_form_wtform_created
 

--- a/indico/modules/events/registration/util.py
+++ b/indico/modules/events/registration/util.py
@@ -10,7 +10,7 @@ import itertools
 from operator import attrgetter
 
 from flask import current_app, json, session
-from marshmallow import EXCLUDE, ValidationError, fields, validates
+from marshmallow import RAISE, ValidationError, fields, validates
 from qrcode import QRCode, constants
 from sqlalchemy import and_, or_
 from sqlalchemy.orm import contains_eager, joinedload, load_only, undefer
@@ -220,7 +220,7 @@ def make_registration_schema(regform, management=False, registration=None):
     """Dynamically create a Marshmallow schema based on the registration form fields."""
     class RegistrationSchema(IndicoSchema):
         class Meta:
-            unknown = EXCLUDE
+            unknown = RAISE
 
         @validates('email')
         def validate_email(self, email, **kwargs):


### PR DESCRIPTION
Adds `mm_field_class` and `mm_field_kwargs` to `RegistrationFormFieldBase`
which are used to dynamically construct the regform schema.

What works:
- regform submission (normal and from management)
- Incorporating field `validators` into the marshmallow schema

What doesn't work yet:
- Modifying existing registrations
