### PR TITLE
Fix wrong timezone in DateInput

### DIFF
--- a/indico/modules/events/registration/client/js/form/fields/DateInput.jsx
+++ b/indico/modules/events/registration/client/js/form/fields/DateInput.jsx
@@ -28,16 +28,7 @@ function DateInputComponent({value, onChange, disabled, required, dateFormat, ti
     const timeString = timeFormat ? timeValue : '00:00:00';
     onChange(`${dateString}T${timeString}`);
   };
-
-  const handleTimeChange = newTime =>
-    onChange(
-      `${dateValue}T${
-        newTime
-          .set('second', 0)
-          .toISOString()
-          .split('T')[1]
-      }`
-    );
+  const handleTimeChange = newTime => onChange(`${dateValue}T${newTime.format('HH:mm:00')}`);
 
   return (
     <Form.Group styleName="date-field">


### PR DESCRIPTION
This PR fixes a bug in which the wrong time was set when selecting from the timepicker widget in any timezone other than UTC+0.